### PR TITLE
Use single-threaded dev server by default.

### DIFF
--- a/syncserver.ini
+++ b/syncserver.ini
@@ -1,8 +1,3 @@
-[server:main]
-use = egg:Paste#http
-host = 0.0.0.0
-port = 5000
-
 [app:main]
 use = egg:syncserver
 
@@ -15,3 +10,12 @@ public_url = http://localhost:5000/
 
 # This is a secret key used for signing authentication tokens.
 #secret = INSERT_SECRET_KEY_HERE
+
+# Use a single-threaded dev server by default.
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 5000
+use_threadpool = true
+threadpool_workers = 1
+threadpool_spawn_if_under = 1


### PR DESCRIPTION
This forces the default dev server to use a single thread, which should fix #2 so it works out of the box.  @callahad can you please try out this branch and see if it fixes the problems reported there?
