### PR TITLE
Use a persistent sqlite db by default, rather than in-memory one.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ local
 \.coverage
 *~
 nosetests.xml
+syncserver.db

--- a/syncserver/__init__.py
+++ b/syncserver/__init__.py
@@ -24,7 +24,8 @@ def includeme(config):
         secret = os.urandom(32).encode("hex")
     sqluri = settings.get("syncserver.sqluri")
     if sqluri is None:
-        sqluri = "sqlite:///:memory:"
+        rootdir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+        sqluri = "sqlite:///" + os.path.join(rootdir, "syncserver.db")
 
     # Configure app-specific defaults based on top-level configuration.
     settings.pop("config", None)


### PR DESCRIPTION
Let's use `./syncserver.db` as the default database, rather than an in-memory sqlite store.  This will be less confusing all round and may help with some strangeness we're seeing with the in-memory db (issue #2).

This change assumes write access to the root checkout directory, but that's highly likely for an initial dev deployment.  The umask is set to ensure that the db gets sensible permissions when it's created.
