### PR TITLE
Add a preliminary Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+##########################################################
+#                  /!\ WARNING /!\                       #
+# This is completely experimental. Use at your own risk. #
+#             Also, learn you some docker:               #
+#           http://docker.io/gettingstarted              #
+##########################################################
+
+FROM debian:7.4
+MAINTAINER Dan Callahan <dan.callahan@gmail.com>
+
+# Base system setup
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    vim locales \
+    && apt-get clean
+
+RUN locale-gen C.UTF-8 && LANG=C.UTF-8 /usr/sbin/update-locale
+
+ENV LANG C.UTF-8
+
+RUN useradd --create-home app
+
+# Build the Sync server
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    build-essential \
+    libzmq-dev \
+    python-dev \
+    python-virtualenv \
+    && apt-get clean
+
+USER app
+
+RUN mkdir -p /home/app/syncserver
+WORKDIR /home/app/syncserver
+
+RUN curl -L https://github.com/mozilla-services/syncserver/tarball/master |\
+    tar xzf - --strip-components=1
+
+RUN make build
+
+# Run the Sync server
+
+EXPOSE 5000
+
+ENTRYPOINT ["/usr/bin/make"]
+CMD ["serve"]


### PR DESCRIPTION
Preliminary work on a Docker version of "[How To Run Firefox Sync 1.5](https://docs.services.mozilla.com/howtos/run-sync-1.5.html)"
## Prerequisites
1. [Docker](http://docker.io)
2. [Firefox 29 (Beta)](https://www.mozilla.org/en-US/firefox/beta/), or newer
## Building and running the server

With the `Dockerfile` below in the current directory, run:
1. `docker build -t sync:server .`
2. `docker run -i -t -p 5000:5000 sync:server`
3. Visit http://localhost:5000, it should say "it works!"
## Starting / Stopping the Sync service

Use `docker ps -a` to see all containers, both running and stopped.

Use `docker stop <container_id>` to stop a running container.

Use `docker start <container_id>` to start a running container.
## Using the server
1. Go to `about:config`, change `services.sync.tokenServerURI` to `http://localhost:5000/token/1.0/sync/1.5`
2. Open the Browser Console (Ctrl-Shift-J)
3. Try to use Firefox Sync -- you should see log output from Docker, and the Browser Console should show connections to `http://localhost:5000`
