### PR TITLE
Ensure that default "audience" URL has no path component.

### DIFF
--- a/syncserver/__init__.py
+++ b/syncserver/__init__.py
@@ -3,7 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-from urlparse import urlparse
+from urlparse import urlparse, urlunparse
 
 from pyramid.response import Response
 from pyramid.events import NewRequest, subscriber
@@ -68,9 +68,10 @@ def includeme(config):
         settings["storage.sqluri"] = sqluri
         settings["storage.create_tables"] = True
     if "browserid.backend" not in settings:
-        # Default to remote verifier, with public_url as only audience
+        # Default to remote verifier, with base of public_url as only audience
+        audience = urlunparse(urlparse(public_url)._replace(path=""))
         settings["browserid.backend"] = "tokenserver.verifiers.RemoteVerifier"
-        settings["browserid.audiences"] = public_url
+        settings["browserid.audiences"] = audience
     if "metlog.backend" not in settings:
         # Default to sending metlog output to stdout.
         settings["metlog.backend"] = "mozsvc.metrics.MetlogPlugin"


### PR DESCRIPTION
The latest verifier is very strict about the format of the "audience" URL - it now enforces that it has a valid scheme, has no path component, etc.  We need to take a bit more care when deriving the default audience from the public_url.

@callahad r?
