### PR TITLE
Update to use new simplified mozsvc.metrics infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test: | $(TOOLS)
 	# $(ENV)/bin/nosetests -s tokenserver.tests
 	
 	# Test against a running server
-	$(ENV)/bin/pserve syncserver/tests.ini & SERVER_PID=$$!; \
+	$(ENV)/bin/pserve syncserver/tests.ini 2> /dev/null & SERVER_PID=$$!; \
 	sleep 2; \
 	$(ENV)/bin/python -m syncstorage.tests.functional.test_storage \
 		--use-token-server http://localhost:5000/token/1.0/sync/1.5; \

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ requests==2.2.1
 simplejson==3.4
 SQLAlchemy==0.9.4
 unittest2==0.5.1
-http://github.com/mozilla-services/mozservices/archive/825cae97e99d1128a07ad8c73dcdc5764562b536.zip
-https://github.com/mozilla-services/tokenserver/archive/02f565379d5af04d23c46d35f3733decd1cab98d.zip
-http://github.com/mozilla-services/server-syncstorage/archive/f4c3b7b1a790430a792f76adf583ea5122381bff.zip
+http://github.com/mozilla-services/mozservices/archive/f279ef02a25755999eada2d7e722d56279ed9fa6.zip
+https://github.com/mozilla-services/tokenserver/archive/175f266b8423a9a48a254044dae807c615ede292.zip
+http://github.com/mozilla-services/server-syncstorage/archive/7eface97e5a8c7c6ee9e7a3f12d02035681543f7.zip

--- a/syncserver/__init__.py
+++ b/syncserver/__init__.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+import logging
 from urlparse import urlparse, urlunparse
 
 from pyramid.response import Response
@@ -72,19 +73,11 @@ def includeme(config):
         audience = urlunparse(urlparse(public_url)._replace(path=""))
         settings["browserid.backend"] = "tokenserver.verifiers.RemoteVerifier"
         settings["browserid.audiences"] = audience
-    if "metlog.backend" not in settings:
-        # Default to sending metlog output to stdout.
-        settings["metlog.backend"] = "mozsvc.metrics.MetlogPlugin"
-        settings["metlog.sender_class"] = "metlog.senders.StdOutSender"
-        settings["metlog.enabled"] = True
-    if "cef.use" not in settings:
-        # Default to sensible CEF logging settings
-        settings["cef.use"] = False
-        settings["cef.file"] = "syslog"
-        settings["cef.vendor"] = "mozilla"
-        settings["cef.version"] = 0
-        settings["cef.device_version"] = 0
-        settings["cef.product"] = "syncserver"
+    if "loggers" not in settings:
+        # Default to basic logging config.
+        root_logger = logging.getLogger("")
+        if not root_logger.handlers:
+            logging.basicConfig(level=logging.INFO)
 
     # Include the relevant sub-packages.
     config.scan("syncserver")

--- a/syncserver/tests.ini
+++ b/syncserver/tests.ini
@@ -15,9 +15,3 @@ public_url = http://localhost:5000/
 
 # This is a secret key used for signing authentication tokens.
 #secret = INSERT_SECRET_KEY_HERE
-
-# Enable metlog during tests, but do not log normal traffic to stdout.
-[metlog]
-backend = "mozsvc.metrics.MetlogPlugin"
-sender_class = "metlog.senders.DebugCaptureSender"
-enabled = True


### PR DESCRIPTION
This updates syncserver to match the newly-simplified metrics-logging infra introduced in https://bugzilla.mozilla.org/show_bug.cgi?id=1012509

Basically, we replace "metlog" with stdlib logging.  There's some new JSON-based logging designed for heka in production, but it's off by default so we don't have to worry about it here.

@callahad r?
