### PR TITLE
Dockerfile: Run apt-get update to fix missing repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ MAINTAINER Dan Callahan <dan.callahan@gmail.com>
 
 # Base system setup
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && apt-get install --no-install-recommends -y \
     vim locales \
     && apt-get clean
 


### PR DESCRIPTION
When running `apt-get install` I was receiving 404s for some repositories, running `apt-get update` before `apt-get install` resolves this.
