### PR TITLE
Use of local browser verification

### DIFF
--- a/syncserver.ini
+++ b/syncserver.ini
@@ -26,3 +26,11 @@ public_url = http://localhost:5000/
 # Set this to "false" to disable new-user signups on the server.
 # Only request by existing accounts will be honoured.
 # allow_new_users = false
+
+# Uncomment and edit the following to use a local browser verifier when
+# running a self hosted Firefox Account and Sync server to use local
+# browser verification. Audiences should be set to your public_url
+# without a trailing slash.
+#[browserid]
+#backend = tokenserver.verifiers.LocalVerifier
+#audiences = https://localhost:5000


### PR DESCRIPTION
Added additional pre-commented options to syncserver.ini to aid in the setup of a fresh sync-server when using a self-hosted accounts server.

Will avoid future reports of this issue: https://github.com/mozilla-services/syncserver/issues/32
