### PR TITLE
Dockerfile: Replace curl of remote source with ADD statement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN useradd --create-home app
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
-    curl \
     build-essential \
     libzmq-dev \
     python-dev \
@@ -34,10 +33,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
 USER app
 
 RUN mkdir -p /home/app/syncserver
+ADD ./ /home/app/syncserver
 WORKDIR /home/app/syncserver
-
-RUN curl -L https://github.com/mozilla-services/syncserver/tarball/master |\
-    tar xzf - --strip-components=1
 
 RUN make build
 


### PR DESCRIPTION
Instead of using `curl` to download a copy of the source inside the docker image, use `ADD` to copy the source from the parent directory of the Dockerfile.
