### PR TITLE
changed http to https in github url

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ zope.component==4.2.1
 configparser==3.5.0b2
 https://github.com/mozilla-services/mozservices/archive/e00e1b68130423ad98d0f6185655bde650443da8.zip
 https://github.com/mozilla-services/tokenserver/archive/92361b0e7b0bff996a8fff9c894c7be850d12d16.zip
-http://github.com/mozilla-services/server-syncstorage/archive/1.5.5.zip
+https://github.com/mozilla-services/server-syncstorage/archive/1.5.5.zip


### PR DESCRIPTION
@rfk added

[`http://github.com/mozilla-services/server-syncstorage/archive/[...]`](https://github.com/mozilla-services/syncserver/blob/d0d47fae3b5b542e7120966d83a927c97dca897a/requirements.txt#L60)

in d0d47fae3b5b542e7120966d83a927c97dca897a (Initial commit) to `requirements.txt` but I think it's better to require

`https://github.com/mozilla-services/server-syncstorage/archive/[...]`

Before I got a `HTTPError: 503 Server Error: Service Unavailable` and `make build` but now it works.