### PR TITLE
Log at WARN level by default, rather than INFO

### DIFF
--- a/syncserver/__init__.py
+++ b/syncserver/__init__.py
@@ -92,7 +92,7 @@ def includeme(config):
         # Default to basic logging config.
         root_logger = logging.getLogger("")
         if not root_logger.handlers:
-            logging.basicConfig(level=logging.INFO)
+            logging.basicConfig(level=logging.WARN)
 
     # Include the relevant sub-packages.
     config.scan("syncserver")


### PR DESCRIPTION
I don't recall ever being glad that we logged at `INFO` by default, and it sure seems to cause concern as found in #31.  Let's bump it up to WARN by default to silence the per-request log noise.