### PR TITLE
Update dependencies to fix LocalVerifier support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ unittest2==1.1
 zope.component==4.2.1
 configparser==3.5
 mozsvc==0.9
-https://github.com/mozilla-services/tokenserver/archive/1.2.23.zip
-https://github.com/mozilla-services/server-syncstorage/archive/1.6.2.zip
+https://github.com/mozilla-services/tokenserver/archive/b6a24f32a56ed4fde25c6b5ebead2f86781a6002.zip
+https://github.com/mozilla-services/server-syncstorage/archive/10ab50027f3d7b5bf7af4354ebdbc62cc6a81a2f.zip

--- a/syncserver/__init__.py
+++ b/syncserver/__init__.py
@@ -114,6 +114,7 @@ def includeme(config):
         settings["fxa.metrics_uid_secret_key"] = os.urandom(16).encode("hex")
 
     # Include the relevant sub-packages.
+    config.scan("syncserver", ignore=["syncserver.wsgi_app"])
     config.include("syncstorage", route_prefix="/storage")
     config.include("tokenserver", route_prefix="/token")
 

--- a/syncserver/__init__.py
+++ b/syncserver/__init__.py
@@ -97,10 +97,10 @@ def includeme(config):
     if "storage.batch_upload_enabled" not in settings:
         settings["storage.batch_upload_enabled"] = False
     if "browserid.backend" not in settings:
-        # Default to remote verifier for simplicity.
+        # Default to local verifier to reduce external dependencies.
         # Use base of public_url as only audience
         audience = urlunparse(urlparse(public_url)._replace(path=""))
-        settings["browserid.backend"] = "tokenserver.verifiers.RemoteVerifier"
+        settings["browserid.backend"] = "tokenserver.verifiers.LocalVerifier"
         settings["browserid.audiences"] = audience
     if "loggers" not in settings:
         # Default to basic logging config.

--- a/syncserver/__init__.py
+++ b/syncserver/__init__.py
@@ -97,10 +97,10 @@ def includeme(config):
     if "storage.batch_upload_enabled" not in settings:
         settings["storage.batch_upload_enabled"] = False
     if "browserid.backend" not in settings:
-        # Default to local verifier to reduce external dependencies.
+        # Default to remote verifier for simplicity.
         # Use base of public_url as only audience
         audience = urlunparse(urlparse(public_url)._replace(path=""))
-        settings["browserid.backend"] = "tokenserver.verifiers.LocalVerifier"
+        settings["browserid.backend"] = "tokenserver.verifiers.RemoteVerifier"
         settings["browserid.audiences"] = audience
     if "loggers" not in settings:
         # Default to basic logging config.


### PR DESCRIPTION
Fixes #91, by pulling in a new version of tokenserver's LocalVerifier class that properly supports the extra "idpClaims" property that we use for tracking FxA generation numbers.