### PR TITLE
Fix Docker 'run' command 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,20 +106,15 @@ Then you can run the server by passing in configuration options as
 environmet variables, like this::
 
     $ docker run --rm \
-        # Expose the port that the server will listen on \
         --network host \
         -p 5000:5000 \
-        # Set important config options through environment variables
         -e SYNCSERVER_PUBLIC_URL=http://localhost:5000 \
         -e SYNCSERVER_SECRET=5up3rS3kr1t \
         -e SYNCSERVER_SQLURI=sqlite:////tmp/syncserver.db \
         -e SYNCSERVER_BATCH_UPLOAD_ENABLED=true \
         -e SYNCSERVER_FORCE_WSGI_ENVIRON=false \
-        # Run the container we just build \
         syncserver:latest \
-        # Start gunicorn on the desired localhost port \
         /usr/local/bin/gunicorn --bind localhost:5000 \
-        # And have it run the syncserver application \
         syncserver.wsgi_app
 
 And you can test whether it's running correctly by using the builtin

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Then you can run the server by passing in configuration options as
 environmet variables, like this::
 
     $ docker run --rm \
-        --network host \
+        -p 631:631 \
         -p 5000:5000 \
         -e SYNCSERVER_PUBLIC_URL=http://localhost:5000 \
         -e SYNCSERVER_SECRET=5up3rS3kr1t \


### PR DESCRIPTION
The official `README.rst` uses `--network host` thus giving the container full access to the host's networking. The following `-p 5000:5000` thus becomes unnecessary.

After quick investigation, I would like to offer a different solution (note: the use of `--network` comes from #90).

Here are the ports used by the container:
```
/ # netstat -tupln
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 127.0.0.1:5000          0.0.0.0:*               LISTEN      1/python2
tcp        0      0 0.0.0.0:34543           0.0.0.0:*               LISTEN      -
tcp        0      0 0.0.0.0:111             0.0.0.0:*               LISTEN      -
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      -
tcp        0      0 127.0.0.1:631           0.0.0.0:*               LISTEN      -
tcp        0      0 0.0.0.0:34359           0.0.0.0:*               LISTEN      -
tcp        0      0 0.0.0.0:45021           0.0.0.0:*               LISTEN      -
tcp        0      0 127.0.0.1:8001          0.0.0.0:*               LISTEN      -
tcp        0      0 0.0.0.0:2049            0.0.0.0:*               LISTEN      -
tcp        0      0 0.0.0.0:38691           0.0.0.0:*               LISTEN      -
tcp        0      0 :::43143                :::*                    LISTEN      -
tcp        0      0 :::111                  :::*                    LISTEN      -
tcp        0      0 :::51155                :::*                    LISTEN      -
tcp        0      0 :::22                   :::*                    LISTEN      -
tcp        0      0 ::1:631                 :::*                    LISTEN      -
tcp        0      0 :::34263                :::*                    LISTEN      -
tcp        0      0 :::2049                 :::*                    LISTEN      -
tcp        0      0 :::44259                :::*                    LISTEN      -
```
After isolating the required ports to be exposed (by changing the `bind` IP address) it looks like we only need `5000` and `631`. However, I have yet to determine which piece of code listen on `631`.

The first commit of this PR only cleanup the Docker command so it can be pasted in a shell without error(s).