### PR TITLE
Upgrade pip when building the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY ./requirements.txt /app/requirements.txt
 COPY ./dev-requirements.txt /app/dev-requirements.txt
 RUN apt-get -q update \
     && apt-get -q --yes install g++ \
+    && pip install --upgrade pip \
     && pip install --upgrade --no-cache-dir -r requirements.txt \
     && pip install --upgrade --no-cache-dir -r dev-requirements.txt \
     && apt-get -q --yes remove g++ \


### PR DESCRIPTION
When building the docker image, I can see the message:
```
You are using pip version 9.0.1, however version 9.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```
So maybe pip can be upgraded when installing the dependencies