### PR TITLE
migrated Dockerfile to be based on alpine linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,21 @@
-FROM python:2.7-slim
+FROM python:2.7-alpine3.7
 
-RUN groupadd --gid 1001 app && \
-    useradd --uid 1001 --gid 1001 --shell /usr/sbin/nologin app
+RUN addgroup -g 1001 app \
+    && adduser -u 1001 -S -D -G app -s /usr/sbin/nologin app
 
 ENV LANG C.UTF-8
 
 WORKDIR /app
 
-# S3 bucket in Cloud Services prod IAM
-ADD https://s3.amazonaws.com/dumb-init-dist/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
-RUN chmod +x /usr/local/bin/dumb-init
-ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
-
 # install syncserver dependencies
 COPY ./requirements.txt /app/requirements.txt
 COPY ./dev-requirements.txt /app/dev-requirements.txt
-RUN apt-get -q update \
-    && apt-get -q --yes install g++ \
+RUN apk --no-cache update \
+    && apk add dumb-init g++ \
     && pip install --upgrade pip \
     && pip install --upgrade --no-cache-dir -r requirements.txt \
     && pip install --upgrade --no-cache-dir -r dev-requirements.txt \
-    && apt-get -q --yes remove g++ \
-    && apt-get -q --yes autoremove \
-    && apt-get clean
+    && apk del g++
 
 COPY ./syncserver /app/syncserver
 COPY ./setup.py /app
@@ -30,3 +23,5 @@ RUN python ./setup.py develop
 
 # run as non priviledged user
 USER app
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
The migration also solves an issue when running this service under ARM based architectures, as the previous usage of dumb-init_1.2.0_amd64 is incompatible on ARM architecture.