### PR TITLE
[docker-entry-point.sh] add missing backslash line continuation

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,8 +5,8 @@ case "$1" in
     server)
         export SYNCSERVER_SQLURI="${SYNCSERVER_SQLURI:-sqlite:///tmp/syncserver.db}"
         exec gunicorn \
-            --bind ${HOST-0.0.0.0}:${PORT-5000}\
-            --forwarded-allow-ips="${SYNCSERVER_FORWARDED_ALLOW_IPS:-127.0.0.1,172.17.0.1}"
+            --bind ${HOST-0.0.0.0}:${PORT-5000} \
+            --forwarded-allow-ips="${SYNCSERVER_FORWARDED_ALLOW_IPS:-127.0.0.1,172.17.0.1}" \
             syncserver.wsgi_app
         ;;
 


### PR DESCRIPTION
ref: https://github.com/mozilla/fxa-dev/issues/397

The previous backslash was a little tucked away, so easy to miss.

r? - @rfk 