### PR TITLE
Improve support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: python
 
 python:
   - "2.7"
+# The way the selection of the Python version is currently made in Makefile
+# leads to travis always picking up Python 2 for the task.
+# All versions of Python are appearantly present in a travis environment.
+# Once the makefile has been adjusted the following lines should be enabled.
+#  - "3.5"
+#  - "3.6"
+#  - "3.7-dev"
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# Once there is Python 3 support in this package and it's dependencies
+# the detection of the used Python version should be changed.
+# The following line prefers `python` as this will allow this to work
+# in CI (e.g. Travis CI) and put up the configured Python version:
+# SYSTEMPYTHON = `which python python3 python2 | head -n 1`
 SYSTEMPYTHON = `which python2 python | head -n 1`
 VIRTUALENV = virtualenv --python=$(SYSTEMPYTHON)
 ENV = ./local

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyramid==1.5
 WebOb==1.4.1
 requests==2.13
 simplejson==3.10
-SQLAlchemy==1.1.5
+SQLAlchemy==1.2.12
 unittest2==1.1
 zope.component==4.2.1
 configparser==3.5

--- a/syncserver.wsgi
+++ b/syncserver.wsgi
@@ -6,7 +6,10 @@ import os
 import sys
 import site
 from logging.config import fileConfig
-from ConfigParser import NoSectionError
+try:
+    from ConfigParser import NoSectionError
+except ImportError:
+    from configparser import NoSectionError
 
 # detecting if virtualenv was used in this dir
 _CURDIR = os.path.dirname(os.path.abspath(__file__))

--- a/syncserver/staticnode.py
+++ b/syncserver/staticnode.py
@@ -10,7 +10,12 @@ are implicitly assigned to a single, static node.
 
 """
 import time
-import urlparse
+
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
+
 from mozsvc.exceptions import BackendError
 
 from sqlalchemy import Column, Integer, String, BigInteger, Index
@@ -98,7 +103,7 @@ class StaticNodeAssignment(object):
     def __init__(self, sqluri, node_url, **kw):
         self.sqluri = sqluri
         self.node_url = node_url
-        self.driver = urlparse.urlparse(sqluri).scheme.lower()
+        self.driver = urlparse(sqluri).scheme.lower()
         sqlkw = {
             "logging_name": "syncserver",
             "connect_args": {},
@@ -111,7 +116,7 @@ class StaticNodeAssignment(object):
             sqlkw["connect_args"]["check_same_thread"] = False
             # If using a :memory: database, we must use a QueuePool of
             # size 1 so that a single connection is shared by all threads.
-            if urlparse.urlparse(sqluri).path.lower() in ("/", "/:memory:"):
+            if urlparse(sqluri).path.lower() in ("/", "/:memory:"):
                 sqlkw["pool_size"] = 1
                 sqlkw["max_overflow"] = 0
         if "mysql" in self.driver:


### PR DESCRIPTION
This pull request aims at making the switch to Python 3 easier.
For most parts this is adjusting imports and some small syntax changes.
The only entirely new part is the generation of a random key. Python 3 does not allow to directly convert _bytes_ to _hex_ and `binascii` allows an approach that runs under Python 2 and 3.

A complete switch isn't possible until [tokenserver](https://github.com/mozilla-services/tokenserver) is compatible with Python 3.
Because of this no real test was possible.
However this should fix the errors reported in #97.

The travis configuration has initially been expanded to use current Python 3s.
But the way the selection of the Python version is made (`SYSTEMPYTHON = …` in Makefile) leads to travis always picking up Python 2 (all versions of Python are appearantly present in a travis environment) for the tasks. 

A proper fix for running in travis would be:

    SYSTEMPYTHON = `which python python3 python2 | head -n 1`

But since this could also affect everyday operation I did not implement it in this branch. Let me know if you think this should be changed!