### PR TITLE
Remove unused dependency simplejson.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ gunicorn==19.6
 pyramid==1.5
 WebOb==1.4.1
 requests==2.13
-simplejson==3.10
 SQLAlchemy==1.2.12
 unittest2==1.1
 zope.component==4.2.1


### PR DESCRIPTION
_simplejson_ is available as the `json` module since Python 2.6.
There isn't any use of the corresponding modules in this package.

If this is required by one of the dependencies I'd suggest for the dependency to require this.