### PR TITLE
makefile: use the system Python's virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ notifications:
     skip_join: false
 
 install:
+  - pip install virtualenv
   - make build
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # in CI (e.g. Travis CI) and put up the configured Python version:
 # SYSTEMPYTHON = `which python python3 python2 | head -n 1`
 SYSTEMPYTHON = `which python2 python | head -n 1`
-VIRTUALENV = virtualenv --python=$(SYSTEMPYTHON)
+VIRTUALENV = $(SYSTEMPYTHON) -m virtualenv --python=$(SYSTEMPYTHON)
 ENV = ./local
 TOOLS := $(addprefix $(ENV)/bin/,flake8 nosetests)
 


### PR DESCRIPTION
`virtualenv` on Fedora is now a Python3 tool. Without installing
Python3, there is no `virtualenv` tool. Instead, just rely on the
package being installed.