### PR TITLE
chore(docs): Clarify docs on using a secret key in docker env vars.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,10 @@ your way.  Things you might like to change include:
     * The database in which to store sync data.  Edit the "sqluri" setting
       under the [syncserver] section.
 
+    * The secret key to use for signing auth tokens.  Find the "secret"
+      entry under the [syncserver] section and follow the instructions
+      in the comment to replace it with a strong random key.
+
 
 Database Backend Modules
 ------------------------
@@ -109,12 +113,15 @@ environmet variables, like this::
     $ docker run --rm \
         -p 5000:5000 \
         -e SYNCSERVER_PUBLIC_URL=http://localhost:5000 \
-        -e SYNCSERVER_SECRET=5up3rS3kr1t \
+        -e SYNCSERVER_SECRET=<PUT YOUR SECRET KEY HERE> \
         -e SYNCSERVER_SQLURI=sqlite:////tmp/syncserver.db \
         -e SYNCSERVER_BATCH_UPLOAD_ENABLED=true \
         -e SYNCSERVER_FORCE_WSGI_ENVIRON=false \
         -e PORT=5000 \
         syncserver:latest
+
+Don't forget to `generate a random secret key <https://mozilla-services.readthedocs.io/en/latest/howtos/run-sync-1.5.html#further-configuration>`_
+to use in the `SYNCSERVER_SECRET` environment variable!
 
 And you can test whether it's running correctly by using the builtin
 function test suite, like so::
@@ -128,7 +135,7 @@ If you'd like a persistent setup, you can mount a volume as well::
         -v /syncserver:/data \
         -p 5000:5000 \
         -e SYNCSERVER_PUBLIC_URL=http://localhost:5000 \
-        -e SYNCSERVER_SECRET=5up3rS3kr1t \
+        -e SYNCSERVER_SECRET=<PUT YOUR SECRET KEY HERE> \
         -e SYNCSERVER_SQLURI=sqlite:////data/syncserver.db \
         -e SYNCSERVER_BATCH_UPLOAD_ENABLED=true \
         -e SYNCSERVER_FORCE_WSGI_ENVIRON=false \


### PR DESCRIPTION
Fixes #161.