### PR TITLE
requirements: Added futures 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ unittest2==1.1
 zope.component==4.2.1
 configparser==3.5
 mozsvc==0.9
+futures==3.0
 https://github.com/mozilla-services/tokenserver/archive/1.3.0.zip
 https://github.com/mozilla-services/server-syncstorage/archive/1.6.13.zip


### PR DESCRIPTION
Required on some systems for gunicorn to be able to start.

Tested on Debian Buster (Stable) x64

See my comment on issue #102 