### PR TITLE
Add support for Freebsd python2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # The following line prefers `python` as this will allow this to work
 # in CI (e.g. Travis CI) and put up the configured Python version:
 # SYSTEMPYTHON = `which python python3 python2 | head -n 1`
-SYSTEMPYTHON = `which python2.7 python2 python | head -n 1`
+SYSTEMPYTHON = `which python2 python2.7 python | head -n 1`
 VIRTUALENV = $(SYSTEMPYTHON) -m virtualenv --python=$(SYSTEMPYTHON)
 ENV = ./local
 TOOLS := $(addprefix $(ENV)/bin/,flake8 nosetests)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # The following line prefers `python` as this will allow this to work
 # in CI (e.g. Travis CI) and put up the configured Python version:
 # SYSTEMPYTHON = `which python python3 python2 | head -n 1`
-SYSTEMPYTHON = `which python2 python | head -n 1`
+SYSTEMPYTHON = `which python2 python python2.7 | head -n 1`
 VIRTUALENV = $(SYSTEMPYTHON) -m virtualenv --python=$(SYSTEMPYTHON)
 ENV = ./local
 TOOLS := $(addprefix $(ENV)/bin/,flake8 nosetests)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # The following line prefers `python` as this will allow this to work
 # in CI (e.g. Travis CI) and put up the configured Python version:
 # SYSTEMPYTHON = `which python python3 python2 | head -n 1`
-SYSTEMPYTHON = `which python2 python python2.7 | head -n 1`
+SYSTEMPYTHON = `which python2.7 python2 python | head -n 1`
 VIRTUALENV = $(SYSTEMPYTHON) -m virtualenv --python=$(SYSTEMPYTHON)
 ENV = ./local
 TOOLS := $(addprefix $(ENV)/bin/,flake8 nosetests)


### PR DESCRIPTION
FreeBSD has recently dropped support for generic `python` and `python2` symlinks. This patch enables syncserver to be built on FreeBSD with `gmake`.