### PR TITLE
Update requirements to fix sync with useOAuthForSyncToken enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY ./requirements.txt /app/requirements.txt
 COPY ./dev-requirements.txt /app/dev-requirements.txt
 RUN apk --no-cache update \
-    && apk add dumb-init libstdc++ libffi-dev openssl-dev g++ \
+    && apk add bash dumb-init gcc libstdc++ libffi-dev make mysql-dev musl-dev ncurses-dev openssl-dev g++ \
     && pip install --upgrade pip \
     && pip install --upgrade --no-cache-dir -r requirements.txt \
     && pip install --upgrade --no-cache-dir -r dev-requirements.txt \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ configparser==3.5
 mozsvc==0.9
 futures==3.0
 soupsieve==1.9.5
-https://github.com/mozilla-services/tokenserver/archive/1.4.5.zip
-https://github.com/mozilla-services/server-syncstorage/archive/1.6.14.zip
+https://github.com/mozilla-services/tokenserver/archive/1.5.11.zip
+https://github.com/mozilla-services/server-syncstorage/archive/1.8.0.zip


### PR DESCRIPTION
This fixes authentication with `identity.sync.useOAuthForSyncToken` enabled which requires newer tokenserver and syncstorage versions.

Thanks to @jackyzy823 for the research :smiley:
I added the necessary dependencies to build readline (probably useless but avoids errors during build).

Closes https://github.com/mozilla-services/syncserver/issues/218 and https://github.com/mozilla-services/syncserver/issues/225.