### PR TITLE
Document support for Docker Compose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,26 @@ If you'd like a persistent setup, you can mount a volume as well::
 Make sure that /syncserver is owned by 1001:1001
 
 
+`Docker Compose <https://docs.docker.com/compose>`_ can also be used for structured deployments::
+
+    version: '3.7'
+    services:
+        syncserver:
+            container_name: syncserver
+            image: mozilla/syncserver:latest
+            volumes:
+                - /syncserver:/data
+            ports:
+                - 5000:5000
+            environment:
+                SYNCSERVER_PUBLIC_URL: 'http://localhost:5000'
+                SYNCSERVER_SECRET: '<PUT YOUR SECRET KEY HERE>'
+                SYNCSERVER_SQLURI: 'sqlite:////data/syncserver.db'
+                SYNCSERVER_BATCH_UPLOAD_ENABLED: 'true'
+                SYNCSERVER_FORCE_WSGI_ENVIRON: 'false'
+                PORT: '5000'
+            restart: always
+
 Removing Mozilla-hosted data
 ----------------------------
 


### PR DESCRIPTION
Add supporting documentation for Docker Compose to README file.

The build process works as expected:

```
docker-compose up -d
Creating network "syncserver-dev_default" with the default driver
Pulling syncserver (mozilla/syncserver:latest)...
latest: Pulling from mozilla/syncserver
aad63a933944: Pull complete
259d822268fb: Pull complete
10ba96d218d3: Pull complete
44ba9f6a4209: Pull complete
8a26115d88f8: Pull complete
defcf1c481a0: Pull complete
bb8ab29b2e39: Pull complete
9943e4b61c11: Pull complete
01f1bf3e93b4: Pull complete
cbbf0a857e73: Pull complete
fb91ebb09e0e: Pull complete
Digest: sha256:57e46530113d99aba9ea5310e98e8e936448e7d99cad7eed5c90e85f908da620
Status: Downloaded newer image for mozilla/syncserver:latest
Creating syncserver ... done
```

It is worth noting that a clean pull of `mozilla/syncserver:latest` appears to be broken, but that is unrelated to the docker-compose.yml structure (which is what I use in my production environment) as it also does not start successfully running directly with docker run.
