### PR TITLE
Remove deprecated "--no-site-packages" flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: build
 .PHONY: build
 build: | $(ENV)/COMPLETE
 $(ENV)/COMPLETE: requirements.txt
-	$(VIRTUALENV) --no-site-packages $(ENV)
+	$(VIRTUALENV) $(ENV)
 	$(INSTALL) -i https://pypi.python.org/simple -U pip
 	$(INSTALL) -r requirements.txt
 	$(ENV)/bin/python ./setup.py develop


### PR DESCRIPTION
This is default since virtualenv 1.9 from 2013-03-07.
It has been deprecated with 1.11 from 2014-01-02.
It has been removed with 20.0.0 from 2020-02-10.

This change hence drops support virtualenv <1.9
but enables support for v20.0.0 and up.

Reference: https://github.com/mozilla-services/syncserver/issues/239#issuecomment-693430113