### PR TITLE
Assure that setuptools <45 is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,10 @@ all: build
 .PHONY: build
 build: | $(ENV)/COMPLETE
 $(ENV)/COMPLETE: requirements.txt
-	$(VIRTUALENV) $(ENV)
-	$(INSTALL) -i https://pypi.python.org/simple -U pip
+	# Install the latest Python 2 compatible setuptools manually:
+	# https://github.com/mozilla-services/syncserver/issues/239
+	$(VIRTUALENV) $(ENV) --no-setuptools
+	$(INSTALL) -U "setuptools<45"
 	$(INSTALL) -r requirements.txt
 	$(ENV)/bin/python ./setup.py develop
 	touch $(ENV)/COMPLETE
@@ -36,7 +38,7 @@ test: | $(TOOLS)
 	$(ENV)/bin/nosetests -s syncstorage.tests
 	# Tokenserver tests currently broken due to incorrect file paths
 	# $(ENV)/bin/nosetests -s tokenserver.tests
-	
+
 	# Test against a running server.
 	$(ENV)/bin/gunicorn --paste syncserver/tests.ini 2> /dev/null & SERVER_PID=$$!; \
 	sleep 2; \


### PR DESCRIPTION
In some circumstances pip pulls setuptools 45.0.0, which is not compatible with Python 2. To assure the correct version is installed, add the "--no-setuptools" flag to virtualenv and install the correct setuptools version manually afterwards.

Workaround for: https://github.com/mozilla-services/syncserver/issues/239
_______________
While this works, it could be added probably more cleanly, e.g. adding `--no-setuptools` to `VIRTUALENV` variable and merging `$(INSTALL) -U "setuptools<45"` with `$(INSTALL) -i https://pypi.python.org/simple -U pip` to:
```
$(INSTALL) -i https://pypi.python.org/simple -U pip "setuptools<45"
```
What was actually the reason for adding the explicit pip install/upgrade? Since `virtualenv` does (or should) do this already. I can only imagine that it was a similar issue than the present one since pip is pulled from an explicit mirror?

Also some comment in code would be a good idea. Please advice about how it is wanted.