### PR TITLE
Add libmysqlclient dependency solution for Debian

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,13 +46,13 @@ following packages (or similar, depending on your operating system) installed:
 syncstorage-rs uses the following additional dependencies:
 
 - cmake
-- golang
+- golang: https://golang.org/doc/install
 - libcurl4-openssl-dev
 - libssl-dev
 - pkg-config
-- Rust stable https://rustup.rs/
+- Rust stable: https://rustup.rs/
 - MySQL 5.7 (or compatible)
-    - libmysqlclient (brew install mysql on macOS, apt install libmysqlclient-dev on Ubuntu)
+    - libmysqlclient ("brew install mysql" on macOS, "apt install libmysqlclient-dev" on Ubuntu, "apt install libmariadb-dev-compat" on Debian)
 
 
 Take a checkout of this repository, then run "make build" to pull in the


### PR DESCRIPTION
On Debian, there is not `libmysqlclient` available since Stretch. Debian has fully migrated to MariaDB as replacement. There is a `libmariadb-dev` package, which ships `libmariadbclient.so`, but this is currently not accepted by the `migrations_macros` compiling step. A simple solution is the available compat package: https://packages.debian.org/libmariadb-dev-compat

Companion to: https://github.com/mozilla-services/syncstorage-rs/pull/847