### PR TITLE
bug: revert cornice update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 gevent==1.4.0
 greenlet==0.4.14
-cornice==3.5.1
+cornice==0.16.2
 gunicorn==19.10.0
 pyramid==1.10.4
 WebOb==1.8.5


### PR DESCRIPTION
Closes: #278

## Description

Revert the previously updated version of Cornice

## Testing

`make test` should pass

## Issue(s)

Closes #278 .
