### PR TITLE
Add support for PostgreSQL to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY ./dev-requirements.txt /app/dev-requirements.txt
 # install the base set of libraries if they're not present.
 # NOTE: please update the README to include any changes.
 RUN apk --no-cache update \
-    && apk add bash dumb-init gcc libstdc++ libffi-dev make mysql-dev musl-dev ncurses-dev openssl-dev g++ \
+    && apk add bash dumb-init gcc libstdc++ libffi-dev make mysql-dev musl-dev ncurses-dev openssl-dev g++ postgresql-dev \
     && pip install --upgrade pip \
     && pip install --upgrade --no-cache-dir -r requirements.txt \
     && pip install --upgrade --no-cache-dir -r dev-requirements.txt \

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ futures==3.2
 soupsieve==1.9.5
 umemcache==1.6.3
 google-cloud-spanner==1.18.0
+psycopg2==2.8.6
 https://github.com/mozilla-services/tokenserver/archive/bf5f232ed78fb4eb89909ec5be40f135945aa514.zip
 https://github.com/mozilla-services/server-syncstorage/archive/d370a488155adeb80ee6f1bc016a4aa9d009f181.zip


### PR DESCRIPTION
## Description

This pull request adds psycopg2 package to Docker image. The package is necessary to support PostgreSQL persistent storage. postgresql-dev package is added because it is a dependency of psycopg2.

## Testing

To test this PR I recommend the following:
1. Install PostgreSQL and create a db with user.
2. Deploy the latest syncserver Docker image and configure it to use the PostgreSQL database.
3. Check if "psycopg is required but not installed" error is present.
4. Build a new Docker image with changes from this PR.
5. Deploy it with the same configuration.
6. Check if database scheme is created properly and the "psycopg2 isn't installed" error is gone.

Example docker-compose:
```
version: "3"
services:
  postgres:
    image: postgres:13
    restart: unless-stopped
    container_name: postgres
    volumes:
      - ./postgres:/var/lib/postgresql/data
    environment:
      POSTGRES_PASSWORD: <password>

  syncserver:
    container_name: syncserver
    image: mozilla/syncserver:latest
    volumes:
       - ./syncserver:/data
    environment:
      SYNCSERVER_PUBLIC_URL: 'http://localhost:5000'
      SYNCSERVER_SECRET: '<secret>'
      SYNCSERVER_SQLURI: 'postgres://<user>:<pass>@postgres:5432/<dbname>'
      SYNCSERVER_BATCH_UPLOAD_ENABLED: 'true'
      SYNCSERVER_FORCE_WSGI_ENVIRON: 'false'
      PORT: '5000'
    restart: unless-stopped
```

## Issue(s)

In [issue](https://github.com/mozilla-services/syncserver/issues/64) it was recommended to install psycopg2 to support PostgreSQL. This recommendation can't be applied to Docker-based deployments. That's why I've decided to create the PR.
