### PR TITLE
Dockerfile: Expose port 5000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN python ./setup.py develop
 # run as non priviledged user
 USER app
 
+# expose the default http port
+EXPOSE 5000
+
 # run the server by default
 ENTRYPOINT ["/usr/bin/dumb-init", "/app/docker-entrypoint.sh"]
 CMD ["server"]


### PR DESCRIPTION
Exposing the port is very helpful on the latest version of Synology's Docker integration into their DiskStation Manager (DSM). Once you expose the port, you can easily set up a reverse proxy on it.

Other Docker-based products might also benefit from it. Therefore I'm contributing this change here.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)